### PR TITLE
element.io defaults for sign in with QR

### DIFF
--- a/element.io/nightly/config.json
+++ b/element.io/nightly/config.json
@@ -52,5 +52,15 @@
     "element_call": {
         "url": "https://element-call.netlify.app"
     },
-    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
+    "login_with_qr": {
+        "login": {
+            "enable_showing": true
+        },
+        "reciprocate": {
+            "enable_scanning": true,
+            "enable_showing": true
+        },
+        "fallback_http_transport_server": "https://rendezvous.lab.element.dev"
+    }
 }

--- a/element.io/release/config.json
+++ b/element.io/release/config.json
@@ -41,5 +41,10 @@
         "apiHost": "https://posthog.element.io"
     },
     "privacy_policy_url": "https://element.io/cookie-policy",
-    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
+    "login_with_qr": {
+        "reciprocate": {
+            "enable_showing": true
+        }
+    }
 }


### PR DESCRIPTION
nightly:
 - enable showing QR at point of login
 - enable showing and scanning QR from settings
 - fallback server configured for when HS doesn't have MSC3886 enabled release:
 - enable showing QR from settings
 - no fallback server

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Ensure your code works with manual testing.
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md)).
